### PR TITLE
have seeding job fail early if not able to finish an API call

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Add a seed command to your package.json
 
 A Chec secret API key must be available in as the environment variable `CHEC_API_KEY` to use for seeding. The script is compatible with [dotenv](https://www.npmjs.com/package/dotenv).
 
-If you want to fail the execution if any seed returns error, provide environment variable `FAIL_EARLY=true`
+If you want to fail the execution if any seed call returns an error, provide environment variable `FAIL_EARLY=true`
 
 ### Global usage
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Add a seed command to your package.json
 
 A Chec secret API key must be available in as the environment variable `CHEC_API_KEY` to use for seeding. The script is compatible with [dotenv](https://www.npmjs.com/package/dotenv).
 
+If you want to fail the execution if any seed returns error, provide environment variable `FAIL_EARLY=true`
+
 ### Global usage
 
 This script can be installed globally:

--- a/index.js
+++ b/index.js
@@ -15,6 +15,8 @@ class Seeder {
   }
 
   async run(path = process.cwd()) {
+    // fail only if env variable equals "true"
+    const shouldFailEarly = !!(process.env.FAIL_EARLY === 'true')
     // Get a list of all seed files in the provided directory
     const entries = Object.entries(this.parsePath(path.replace(new RegExp(`${sep}$`), '')));
 
@@ -73,7 +75,11 @@ class Seeder {
                 if (this.showSpinner) {
                   this.spinner.stop();
                 }
-                this.log(`Could not push an object to the ${chalk.dim(endpoint)} endpoint (${error.message}):`);
+                if (shouldFailEarly) {
+                  this.spinner.fail(`Could not push an object to the ${chalk.dim(endpoint)} endpoint (${error.message})`);
+                  throw error
+                }
+                this.log(`Could not push an object to the ${chalk.dim(endpoint)} endpoint (${error.message}). Resuming`);
                 if (this.showSpinner) {
                   this.spinner.start()
                 }


### PR DESCRIPTION
Related to #8.
This should fail an execution of this seeding job at any point if error is returned from the API - I have added new env variable to be backward compatible.

@ScopeyNZ you mentioned in the issue that this task would require some refactor - I don't mind removing promise-queue altogether but I'm not that familiar with the feature to do some proper testing afterwards. I can create new PR for this later if you are willing to test it 😄 

Cheers