### PR TITLE
404 seeding error fix

### DIFF
--- a/index.js
+++ b/index.js
@@ -192,7 +192,7 @@ class Seeder {
       'x-authorization': key,
     };
 
-    return got(`${url}/${endpoint}`, {
+    return got(`${url}${endpoint}`, {
       method: 'post',
       body: JSON.stringify(payload),
       headers,


### PR DESCRIPTION
additional "/" is added to url which causes it to call "https://api.chec.io//v1/categories" resulting in 404. This fix removes the extra slash and has been tested to work.